### PR TITLE
v0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ fastlane add_plugin google_drive
 
 > Please refer to [this guide](https://github.com/gimite/google-drive-ruby/blob/master/doc/authorization.md) to create an Google Drive credential.
 
+Upload files to Google Drive folder.
+> Aliases for this action - `google_drive_upload` and `upload_google_drive` will be deprecated in next version.
+
 ```ruby
 upload_to_google_drive(
   drive_keyfile: 'drive_key.json',
@@ -27,8 +30,7 @@ upload_to_google_drive(
 )
 ```
 
-Upload files to Google Drive folder.
-You can also use `google_drive_upload` or `upload_google_drive` as aliases.
+Create new Google Drive folder
 
 ```ruby
 create_google_drive_folder(
@@ -37,8 +39,6 @@ create_google_drive_folder(
   folder_title: 'new_folder'
 )
 ```
-
-Create new Google Drive folder
 
 Download feature is not implemented yet. PR is always welcome.
 
@@ -80,4 +80,4 @@ _fastlane_ is the easiest way to automate beta deployments and releases for your
 
 The MIT License (MIT)
 
-Copyright (c) 2018 Bumsoo Kim (<https://bsk.im>)
+Copyright (c) 2019 Bumsoo Kim (<https://bsk.im>)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,7 +4,7 @@ lane :test do |options|
   folder_id = options[:folder_id] || UI.input('Please enter Google Drive target id: ')
   file_to_upload = options[:upload_file] || UI.input('Please enter path for file to upload: ')
 
-  upload_google_drive(
+  upload_to_google_drive(
     drive_keyfile: drive_keyfile,
     service_account: service_account,
     folder_id: folder_id,

--- a/lib/fastlane/plugin/google_drive/actions/google_drive_upload_action.rb
+++ b/lib/fastlane/plugin/google_drive/actions/google_drive_upload_action.rb
@@ -9,6 +9,16 @@ module Fastlane
       def self.description
         "Alias for the `upload_to_google_drive` action"
       end
+
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        [
+          "Please use `upload_to_google_drive` instead."
+        ].join("\n")
+      end
     end
   end
 end

--- a/lib/fastlane/plugin/google_drive/actions/upload_google_drive_action.rb
+++ b/lib/fastlane/plugin/google_drive/actions/upload_google_drive_action.rb
@@ -9,6 +9,16 @@ module Fastlane
       def self.description
         "Alias for the `upload_to_google_drive` action"
       end
+
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        [
+          "Please use `upload_to_google_drive` instead."
+        ].join("\n")
+      end
     end
   end
 end

--- a/lib/fastlane/plugin/google_drive/version.rb
+++ b/lib/fastlane/plugin/google_drive/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module GoogleDrive
-    VERSION = "0.4.0"
+    VERSION = "0.4.1"
   end
 end


### PR DESCRIPTION
deprecation notice for aliases `google_drive_upload` and `upload_google_drive`