### PR TITLE
Add optional flag to make uploaded files urls open to public

### DIFF
--- a/lib/fastlane/plugin/google_drive/helper/google_drive_helper.rb
+++ b/lib/fastlane/plugin/google_drive/helper/google_drive_helper.rb
@@ -36,6 +36,19 @@ module Fastlane
         end
       end
 
+      def self.create_public_url(file)
+        raise "Not Google Drive file" unless file.kind_of?(::GoogleDrive::File)
+
+        begin
+          file.acl.push(type: "anyone", role: "reader")
+          file.reload_metadata
+          file.human_url
+        rescue Exception => e
+          UI.error(e.message)
+          UI.user_error!("Create public link for '#{file.resource_id}' failed")
+        end
+      end
+
       def self.create_subcollection(root_folder:, title:)
         root_folder.create_subcollection(title)
       rescue Exception => e


### PR DESCRIPTION
Add the optional parameter `:public_links` to `upload_to_google_drive`, which if enabled will add an ACL entry for each file uploaded, allowing anyone read access.