### PR TITLE
fix(#26): added check_existing parameter for create_google_drive_folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ Create new Google Drive folder:
 create_google_drive_folder(
   drive_keyfile: 'drive_key.json',
   folder_id: '#{folder_id}',
-  folder_title: 'new_folder'
+  folder_title: 'new_folder',
+  check_existing: false  # optional, default is false
 )
 ```
+If `check_existing` is `true`, checks and returns existing folder.
 
 Update the content of existing Google Drive file:
 

--- a/lib/fastlane/plugin/google_drive/actions/create_google_drive_folder_action.rb
+++ b/lib/fastlane/plugin/google_drive/actions/create_google_drive_folder_action.rb
@@ -77,7 +77,13 @@ module Fastlane
                                        type: String,
                                        verify_block: proc do |value|
                                          UI.user_error!("No folder title given") if value.nil? || value.empty?
-                                       end)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :check_existing,
+                                       env_name: "GDRIVE_FOLDER_CHECK_EXISTING",
+                                       description: "Check for existing folder before creation",
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/google_drive/actions/create_google_drive_folder_action.rb
+++ b/lib/fastlane/plugin/google_drive/actions/create_google_drive_folder_action.rb
@@ -21,9 +21,10 @@ module Fastlane
         )
 
         title = params[:folder_title]
+        check_existing = params[:check_existing]
         UI.message('------------------')
         UI.important("Creating #{title}")
-        new_folder = Helper::GoogleDriveHelper.create_subcollection(root_folder: folder, title: title)
+        new_folder = Helper::GoogleDriveHelper.create_subcollection(root_folder: folder, title: title, check_existing: check_existing)
         UI.success('Success')
         UI.message('------------------')
 

--- a/lib/fastlane/plugin/google_drive/helper/google_drive_helper.rb
+++ b/lib/fastlane/plugin/google_drive/helper/google_drive_helper.rb
@@ -49,8 +49,13 @@ module Fastlane
         end
       end
 
-      def self.create_subcollection(root_folder:, title:)
-        root_folder.create_subcollection(title)
+      def self.create_subcollection(root_folder:, title:, check_existing: false)
+        existing_folder = check_existing ? root_folder.subcollection_by_title(title) : nil
+        if existing_folder.nil?
+          root_folder.create_subcollection(title)
+        else
+          existing_folder
+        end
       rescue Exception => e
         UI.error(e.message)
         UI.user_error!("Create '#{title}' failed")

--- a/spec/create_google_drive_folder_action_spec.rb
+++ b/spec/create_google_drive_folder_action_spec.rb
@@ -60,6 +60,27 @@ describe Fastlane::Actions::CreateGoogleDriveFolderAction do
     end
   end
 
+  context 'when check_existing and folder exists' do
+    let(:existing_folder) { double('GoogleDrive::Collection') }
+    before do
+      allow_any_instance_of(GoogleDrive::Collection).to receive(:subcollection_by_title).and_return(existing_folder)
+      allow(existing_folder).to receive(:resource_id).and_return('folder:abcdefg')
+      allow(existing_folder).to receive(:human_url).and_return('https://example.com/abcdefg')
+    end
+
+    it 'set lane_context with existing folder' do
+      expect_any_instance_of(GoogleDrive::Collection).to receive(:subcollection_by_title).with('new_folder')
+
+      folder_id = ENV['TEST_UPLOAD_FOLDER_ID']
+      Fastlane::FastFile.new.parse("lane :test do
+      create_google_drive_folder(drive_keyfile: '#{@key_path}', folder_id: '#{folder_id}', folder_title: 'new_folder', check_existing: true)
+    end").runner.execute(:test)
+
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GDRIVE_CREATED_FOLDER_ID]).to eq('abcdefg')
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GDRIVE_CREATED_FOLDER_URL]).to eq('https://example.com/abcdefg')
+    end
+  end
+
   context 'when creating is succeeded' do
     let(:new_folder) { double('GoogleDrive::Collection') }
     before do


### PR DESCRIPTION
This PR fixes issue #26 by adding optional `check_existing` parameter for `create_google_drive_folder` action. The value is `false` by default to avoid breaking existing logic.

@bskim45 FYI