### PR TITLE
ci: drop support for ruby 2.6

### DIFF
--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Ruby version matrix in the CI/CD workflow to remove support for Ruby 2.6, focusing testing on more current versions (2.7, 3.0, 3.1, 3.2, 3.3).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->