### PR TITLE
ci: replace archived codeclimate-action with qlty-action

### DIFF
--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
@@ -52,13 +55,14 @@ jobs:
           TEST_CHECK_EXISTENCE_PARENT_FOLDER_ID: "${{ secrets.TEST_CHECK_EXISTENCE_PARENT_FOLDER_ID }}"
           TEST_CHECK_EXISTENCE_FILE_TITLE: "${{ vars.TEST_CHECK_EXISTENCE_FILE_TITLE }}"
           TEST_CHECK_EXISTENCE_FOLDER_TITLE: "${{ vars.TEST_CHECK_EXISTENCE_FOLDER_TITLE }}"
-          # https://github.com/simplecov-ruby/simplecov#json-formatter
-          CC_TEST_REPORTER_ID: "${{ secrets.CC_TEST_REPORTER_ID }}"
 
-      - uses: paambaati/codeclimate-action@v9.0.0
+      - name: Upload coverage to Qlty Cloud
+        uses: qltysh/qlty-action/coverage@v2
         if: matrix.ruby-version == '3.1'
-        env:
-          CC_TEST_REPORTER_ID: "${{ secrets.CC_TEST_REPORTER_ID }}"
+        with:
+          oidc: true
+          files: coverage/coverage.json
+          format: simplecov
 
   build_and_publish:
     name: Build and Publish


### PR DESCRIPTION
## Summary
- `paambaati/codeclimate-action` is [archived](https://github.com/paambaati/codeclimate-action) and the CodeClimate test-reporter download now returns 404, breaking coverage upload on Ruby 3.1 (see #47 / #48 CI logs).
- Migrate to `qltysh/qlty-action/coverage@v2` per the [qlty migration guide](https://docs.qlty.sh/migration/coverage).
- Uses **OIDC** auth (no token secret required); added `id-token: write` permission to the `test` job.
- Points the uploader at `coverage/coverage.json` (SimpleCov JSON formatter output) with `format: simplecov`.

## Follow-ups
- Register this repo on [Qlty Cloud](https://qlty.sh) and enable OIDC so the upload succeeds. The step is gated to Ruby 3.1 and uses `skip-errors: true` by default, so failures here won't break CI.
- The stale `CC_TEST_REPORTER_ID` secret can be removed from the repo settings.
- Does not address the Ruby 2.7 `ostruct` Gemfile mismatch — tracked separately.

## Test plan
- [ ] CI runs on this PR
- [ ] Ruby 3.1 job reaches the qlty upload step and either uploads successfully (once Qlty Cloud is set up) or no-ops without failing the build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline security permissions for automated testing.
  * Changed coverage reporting integration to use Qlty Cloud for Ruby 3.1+ builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->